### PR TITLE
conflicting dependencies

### DIFF
--- a/liveedgedetection/build.gradle
+++ b/liveedgedetection/build.gradle
@@ -18,10 +18,16 @@ android {
             proguardFiles getDefaultProguardFile('proguard-android.txt'), 'proguard-rules.pro'
         }
     }
+
+    compileOptions {
+        sourceCompatibility 1.8
+        targetCompatibility 1.8
+    }
 }
 
 dependencies {
     implementation 'androidx.appcompat:appcompat:1.2.0'
+    implementation 'androidx.lifecycle:lifecycle-extensions:2.2.0'
     api 'com.github.MikeOrtiz:TouchImageView:3.0.3'
     implementation 'com.jakewharton.timber:timber:4.7.1'
     // The source code of OpenCV is here https://git.mxtracks.info/opencv/openCV-android-sdk


### PR DESCRIPTION
It fixes Cannot access 'androidx.lifecycle.HasDefaultViewModelProviderFactory' which is a supertype of 'info.hannes.liveedgedetection.activity.ScanActivity'. Check your module classpath for missing or conflicting dependencies