### PR TITLE
Update Gradle Wrapper from 7.4.1 to 7.4.2

### DIFF
--- a/gradle/wrapper/gradle-wrapper.properties
+++ b/gradle/wrapper/gradle-wrapper.properties
@@ -1,5 +1,5 @@
 distributionBase=GRADLE_USER_HOME
 distributionPath=wrapper/dists
-distributionUrl=https\://services.gradle.org/distributions/gradle-7.4.1-bin.zip
+distributionUrl=https\://services.gradle.org/distributions/gradle-7.4.2-bin.zip
 zipStoreBase=GRADLE_USER_HOME
 zipStorePath=wrapper/dists


### PR DESCRIPTION
Update Gradle Wrapper from 7.4.1 to 7.4.2.

Read the release notes: https://docs.gradle.org/7.4.2/release-notes.html

---

The checksums of the Wrapper JAR and the distribution binary have been successfully verified.

- Gradle release: `7.4.2`
- Distribution (-bin) zip checksum: `29e49b10984e585d8118b7d0bc452f944e386458df27371b49b4ac1dec4b7fda`
- Wrapper JAR Checksum: `575098db54a998ff1c6770b352c3b16766c09848bee7555dab09afc34e8cf590`

You can find the reference checksum values at https://gradle.org/release-checksums/

---

🤖 This PR has been created by the [Update Gradle Wrapper](https://github.com/gradle-update/update-gradle-wrapper-action) action.

<details>
<summary>Need help? 🤔</summary>
<br />

If something doesn't look right with this PR please file an issue [here](https://github.com/gradle-update/update-gradle-wrapper-action/issues).
</details>